### PR TITLE
Decouple tile fetching from mesh generation

### DIFF
--- a/examples/simple/index.ts
+++ b/examples/simple/index.ts
@@ -5,16 +5,19 @@ import "./main.css";
 const Cesium: any = require("cesiumSource/Cesium");
 // Import @types/cesium to use along with CesiumJS
 import { Viewer, Ion, IonResource, createWorldTerrain } from "cesium";
-import TerrainProvider from "../../dist";
+import TerrainProvider, { MapboxTerrainResource } from "../../dist";
 
-const terrainProvider = new TerrainProvider({
-  // @ts-ignore
-  url: IonResource.fromAssetId("1"),
-  requestVertexNormals: false,
-  requestWaterMask: false,
+// @ts-ignore
+const terrainResource = new MapboxTerrainResource({
   accessToken: process.env.MAPBOX_API_TOKEN,
   highResolution: false,
   skipOddLevels: false,
+});
+
+const terrainProvider = new TerrainProvider({
+  resource: terrainResource,
+  requestVertexNormals: false,
+  requestWaterMask: false,
 });
 
 let satellite = new Cesium.MapboxImageryProvider({

--- a/examples/simple/index.ts
+++ b/examples/simple/index.ts
@@ -5,19 +5,15 @@ import "./main.css";
 const Cesium: any = require("cesiumSource/Cesium");
 // Import @types/cesium to use along with CesiumJS
 import { Viewer, Ion, IonResource, createWorldTerrain } from "cesium";
-import TerrainProvider, { MapboxTerrainResource } from "../../dist";
+import TerrainProvider from "../../dist";
 
 // @ts-ignore
-const terrainResource = new MapboxTerrainResource({
-  accessToken: process.env.MAPBOX_API_TOKEN,
-  highResolution: false,
-  skipOddLevels: false,
-});
-
 const terrainProvider = new TerrainProvider({
-  resource: terrainResource,
   requestVertexNormals: false,
   requestWaterMask: false,
+  accessToken: process.env.MAPBOX_API_TOKEN,
+  skipOddLevels: false,
+  highResolution: false,
 });
 
 let satellite = new Cesium.MapboxImageryProvider({

--- a/src/heightmap-resource.ts
+++ b/src/heightmap-resource.ts
@@ -1,0 +1,103 @@
+import { Resource } from "cesium";
+import { TileCoordinates } from "./terrain-provider";
+
+export interface HeightmapResource {
+  tileSize: number;
+  getTilePixels: (coords: TileCoordinates) => Promise<ImageData>;
+  getTileDataAvailable: (coords: TileCoordinates) => boolean;
+}
+
+interface CanvasRef {
+  canvas: HTMLCanvasElement;
+  context: CanvasRenderingContext2D;
+}
+
+const loadImage: (url: string) => Promise<HTMLImageElement> = (url) =>
+  new Promise((resolve, reject) => {
+    const img = new Image();
+    img.addEventListener("load", () => resolve(img));
+    img.addEventListener("error", (err) => reject(err));
+    img.crossOrigin = "anonymous";
+    img.src = url;
+  });
+
+export interface DefaultHeightmapResourceOpts {
+  url?: string;
+  skipOddLevels?: boolean;
+  maxZoom?: number;
+  tileSize?: number;
+}
+
+export class DefaultHeightmapResource implements HeightmapResource {
+  resource: Resource = null;
+  tileSize: number = 256;
+  maxZoom: number;
+  skipOddLevels: boolean = false;
+  contextQueue: CanvasRef[];
+
+  constructor(opts: DefaultHeightmapResourceOpts = {}) {
+    if (opts.url) {
+      this.resource = Resource.createIfNeeded(opts.url);
+    }
+    this.skipOddLevels = opts.skipOddLevels ?? false;
+    this.tileSize = opts.tileSize ?? 256;
+    this.maxZoom = opts.maxZoom ?? 15;
+    this.contextQueue = [];
+  }
+
+  getCanvas(): CanvasRef {
+    let ctx = this.contextQueue.pop();
+    if (ctx == null) {
+      const canvas = document.createElement("canvas");
+      canvas.width = this.tileSize;
+      canvas.height = this.tileSize;
+      const context = canvas.getContext("2d");
+      ctx = {
+        canvas,
+        context,
+      };
+    }
+    return ctx;
+  }
+
+  getPixels(img: HTMLImageElement | HTMLCanvasElement): ImageData {
+    const canvasRef = this.getCanvas();
+    const { context } = canvasRef;
+    //context.scale(1, -1);
+    // Chrome appears to vertically flip the image for reasons that are unclear
+    // We can make it work in Chrome by drawing the image upside-down at this step.
+    context.drawImage(img, 0, 0, this.tileSize, this.tileSize);
+    const pixels = context.getImageData(0, 0, this.tileSize, this.tileSize);
+    context.clearRect(0, 0, this.tileSize, this.tileSize);
+    this.contextQueue.push(canvasRef);
+    return pixels;
+  }
+
+  buildTileURL(tileCoords: TileCoordinates) {
+    // reverseY for TMS tiling (https://gist.github.com/tmcw/4954720)
+    // See tiling schemes here: https://www.maptiler.com/google-maps-coordinates-tile-bounds-projection/
+    const { z, y } = tileCoords;
+    return this.resource?.getDerivedResource({
+      templateValues: {
+        ...tileCoords,
+        reverseY: Math.pow(2, z) - y - 1,
+      },
+      preserveQueryParameters: true,
+    }).getUrlComponent(true);
+  }
+
+  getTilePixels = async (coords: TileCoordinates) => {
+    const url = this.buildTileURL(coords);
+    let img = await loadImage(url);
+    return this.getPixels(img);
+  }
+
+  getTileDataAvailable({ z }) {
+    if (z == this.maxZoom) return true;
+    if (z % 2 == 1 && this.skipOddLevels) return false;
+    if (z > this.maxZoom) return false;
+    return true;
+  }
+}
+
+export default DefaultHeightmapResource;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,10 @@
-import MapboxTerrainProvider from './terrain-provider'
-export default MapboxTerrainProvider
+import DefaultHeightmapResource from './heightmap-resource'
+import MapboxTerrainResource from './mapbox-resource'
+import MartiniTerrainProvider from './terrain-provider'
+
+export default MartiniTerrainProvider
+export {
+    MartiniTerrainProvider,
+    DefaultHeightmapResource,
+    MapboxTerrainResource
+}

--- a/src/mapbox-resource.ts
+++ b/src/mapbox-resource.ts
@@ -1,0 +1,44 @@
+import { Resource } from "cesium";
+import { DefaultHeightmapResource, DefaultHeightmapResourceOpts } from "./heightmap-resource";
+import { TileCoordinates } from "./terrain-provider";
+
+export enum ImageFormat {
+  WEBP = "webp",
+  PNG = "png",
+  PNGRAW = "pngraw",
+}
+
+export type MapboxTerrainResourceOpts = {
+  highResolution?: boolean;
+  imageFormat?: ImageFormat;
+  accessToken?: string;
+} & DefaultHeightmapResourceOpts;
+
+export class MapboxTerrainResource extends DefaultHeightmapResource {
+  resource: Resource = null;
+
+  constructor(opts: MapboxTerrainResourceOpts = {}) {
+    super(opts);
+    const highResolution = opts.highResolution ?? false;
+    const format = opts.imageFormat ?? ImageFormat.WEBP;
+
+    // overrides based on highResolution flag
+    if (highResolution) {
+      if (opts.maxZoom === undefined) {
+        this.maxZoom = 14;
+      }
+      if (opts.tileSize === undefined) {
+        this.tileSize = 512;
+      }
+    }
+    
+    this.resource = Resource.createIfNeeded(`https://api.mapbox.com/v4/mapbox.terrain-rgb/{z}/{x}/{y}${highResolution ? "@2x" : ""}.${format}`);
+    if (opts.accessToken) {
+      this.resource.setQueryParameters({
+        access_token: opts.accessToken
+      });
+    }
+  }
+}
+
+export default MapboxTerrainResource;

--- a/src/terrain-provider.ts
+++ b/src/terrain-provider.ts
@@ -5,16 +5,12 @@ import {
   WebMercatorTilingScheme,
   Math as CMath,
   Event as CEvent,
-  Cartesian3,
   BoundingSphere,
   QuantizedMeshTerrainData,
   HeightmapTerrainData,
   OrientedBoundingBox,
   TerrainProvider,
   Credit,
-  Matrix3,
-  Resource,
-  defaultValue
 } from "cesium";
 const ndarray = require("ndarray");
 import Martini from "../martini/index.js";
@@ -22,7 +18,7 @@ import WorkerFarm from "./worker-farm";
 import { TerrainWorkerInput, decodeTerrain } from "./worker";
 import TilingScheme from "cesium/Source/Core/TilingScheme";
 import { HeightmapResource } from './heightmap-resource';
-import MapboxTerrainResource from "./mapbox-resource.js";
+import MapboxTerrainResource, { MapboxTerrainResourceOpts } from "./mapbox-resource";
 
 // https://github.com/CesiumGS/cesium/blob/1.68/Source/Scene/MapboxImageryProvider.js#L42
 
@@ -35,7 +31,7 @@ export interface TileCoordinates {
 interface MartiniTerrainOpts {
   resource: HeightmapResource;
   ellipsoid?: Ellipsoid;
-  workerURL: string;
+  // workerURL: string;
   detailScalar?: number;
   minimumErrorLevel?: number;
   maxWorkers?: number;
@@ -43,7 +39,7 @@ interface MartiniTerrainOpts {
   offset?: number;
 }
 
-class MartiniTerrainProvider<TerrainProvider> {
+export class MartiniTerrainProvider<TerrainProvider> {
   hasWaterMask = false;
   hasVertexNormals = false;
   credit = new Credit("Mapbox");
@@ -254,4 +250,15 @@ class MartiniTerrainProvider<TerrainProvider> {
   }
 }
 
-export default MartiniTerrainProvider;
+
+type MapboxTerrainOpts = Omit<MartiniTerrainOpts, 'resource'> & MapboxTerrainResourceOpts;
+
+export default class MapboxTerrainProvider extends MartiniTerrainProvider<TerrainProvider> {
+  constructor(opts: MapboxTerrainOpts = {}) {
+    const resource = new MapboxTerrainResource(opts);
+    super({
+      ...opts,
+      resource,
+    });
+  }
+}


### PR DESCRIPTION
I have a need to consume and merge multiple terrain datasources. The logic for fetching tiles and generating terrain are contained in the same class, making this task difficult.

This PR decouples the tile fetching from the terrain generation, such that the source of the terrain tiles can be implemented independently from the terrain. This also allows the Mapbox-specific parameters (e.g. access token, high resolution) to be isolated to the MapboxTerrainResource class. A base class DefaultHeightmapResource is provided with the relevant fetching logic extracted from MartiniTerrainProvider.

The simple example shows the minimal changes required to compose these classes.

Apart from a clean separation of concerns, this change allows me to write a new CompositeHeightmapResource class that will take an array of HeightmapResource instances. Available terrain tiles from these resources will be combined into a single image, which will then be consumed by the terrain provider as usual.

