### PR TITLE
Fix for failing webpack builds in Cesium

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@babel/preset-env": "^7.11.0",
     "@babel/preset-typescript": "^7.10.4",
     "@macrostrat/hyper": "^1.2.13",
+    "@open-wc/webpack-import-meta-loader": "^0.4.7",
     "@rollup/plugin-babel": "^5.3.0",
     "@rollup/plugin-commonjs": "^17.0.0",
     "@rollup/plugin-node-resolve": "^7.1.3",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -35,7 +35,13 @@ module.exports = {
         enforce: "pre",
         test: /\.js$/,
         loader: "source-map-loader"
-      }
+      },
+      // https://github.com/CesiumGS/cesium/issues/9790#issuecomment-943773870
+      {
+        test: /.js$/,
+        include: path.resolve(__dirname, 'node_modules/cesium/Source'),
+        use: { loader: require.resolve('@open-wc/webpack-import-meta-loader') }
+      },
     ]
   },
   node: {


### PR DESCRIPTION
As per the discussion at https://github.com/CesiumGS/cesium/issues/9790 the third party zip module fails to build correctly in webpack. The suggested fix involves adding @open-wc/webpack-import-meta-loader rule as mentioned here https://github.com/CesiumGS/cesium/issues/9790#issuecomment-943773870

This PR doesn't bump up the Cesium version, but fixes the current build error in my usage.