### PR TITLE
Custom decode function

### DIFF
--- a/src/heightmap-resource.ts
+++ b/src/heightmap-resource.ts
@@ -1,10 +1,12 @@
 import { Resource } from "cesium";
 import { TileCoordinates } from "./terrain-provider";
+import { DecodeRgbFunction } from "./types";
 
 export interface HeightmapResource {
   tileSize: number;
   getTilePixels: (coords: TileCoordinates) => Promise<ImageData>;
   getTileDataAvailable: (coords: TileCoordinates) => boolean;
+  decodeRgb: DecodeRgbFunction | null;
 }
 
 interface CanvasRef {
@@ -26,6 +28,7 @@ export interface DefaultHeightmapResourceOpts {
   skipOddLevels?: boolean;
   maxZoom?: number;
   tileSize?: number;
+  decodeRgb?: DecodeRgbFunction;
 }
 
 export class DefaultHeightmapResource implements HeightmapResource {
@@ -34,6 +37,7 @@ export class DefaultHeightmapResource implements HeightmapResource {
   maxZoom: number;
   skipOddLevels: boolean = false;
   contextQueue: CanvasRef[];
+  decodeRgb: DecodeRgbFunction = null;
 
   constructor(opts: DefaultHeightmapResourceOpts = {}) {
     if (opts.url) {
@@ -43,6 +47,7 @@ export class DefaultHeightmapResource implements HeightmapResource {
     this.tileSize = opts.tileSize ?? 256;
     this.maxZoom = opts.maxZoom ?? 15;
     this.contextQueue = [];
+    this.decodeRgb = opts.decodeRgb;
   }
 
   getCanvas(): CanvasRef {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,65 @@
+/**
+ * Function used to convert RGBA packed data into floating-point value.
+ * 
+ * Since this operates across Web Worker boundaries, it must only utilise the given parameter list.
+ * External references not supported.
+ * 
+ * Supported function syntax:
+ *   1) (r, g, b, a) => 0.0
+ *   2) (r, g, b) => {
+ *          return 0.0;
+ *      }
+ *   3) function f(r, g, b, a) {
+ *          return 0.0;
+ *      }
+ */
+export type DecodeRgbFunction = (r: number, g: number, b: number, a: number) => number;
+
+/**
+ * Regex supports the following function syntax:
+ * 1) a => a * 2
+ * 2) a => {
+ *        const x = a * 2;
+ *        return x;
+ *    }
+ * 3) (a, b) => a + b
+ * 4) function f(a) {
+ *        return a * 2;
+ *    } 
+ */
+ const functionParser = /^(?:(?:function\s+\w+\s*)?\(?(?<params>(?:\w+\s*,?\s*)*)\)?\s*(?:=>)?\s*\{?(?<body>(?:.|[\s\n])+?)\}?)$/gi;
+
+ // mapbox Terrain-RGB default decode function
+ const defaultDecodeRgb = (r, g, b, a) => (r * 256 * 256) * 0.1 + (g * 256.0) * 0.1 + b * 0.1 - 10000;
+ 
+ /**
+  * @param fn DecodeRgbFunction callable or string representation of a DecodeRgbFunction.
+  * @returns A concrete DecodeRgbFunction callable.
+  */
+export function getDecodeRgbFunction(fn: DecodeRgbFunction | string | null, cache?: { [key: string]: DecodeRgbFunction }): DecodeRgbFunction {
+  if (!fn) return defaultDecodeRgb;
+
+  if (typeof fn === 'string') {
+    if (cache?.[fn]) return cache[fn];
+    try {
+      // parse function string
+      const { groups: { params, body } } = functionParser.exec(fn.trim());
+      const retfn = new Function(
+        ...params.split(',').map(x => x.trim()),
+        body.trim(),
+      ) as DecodeRgbFunction;
+      if (cache) {
+        cache[fn] = retfn;
+      }
+
+      return retfn;
+    } catch {
+      // malformed transform function, or potential CSP error
+    }
+  } else if (typeof fn === 'function') {
+    return fn;
+  }
+
+  return defaultDecodeRgb;
+}
+ 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -29,8 +29,10 @@ export type DecodeRgbFunction = (r: number, g: number, b: number, a: number) => 
  */
  const functionParser = /^(?:(?:function\s+\w+\s*)?\(?(?<params>(?:\w+\s*,?\s*)*)\)?\s*(?:=>)?\s*\{?(?<body>(?:.|[\s\n])+?)\}?)$/gi;
 
- // mapbox Terrain-RGB default decode function
- const defaultDecodeRgb = (r, g, b, a) => (r * 256 * 256) * 0.1 + (g * 256.0) * 0.1 + b * 0.1 - 10000;
+ /** Mapbox Terrain-RGB default decode function
+  *  (r * 256 * 256) / 10 + (g * 256) / 10 + b / 10 - 10000
+  */
+ const defaultDecodeRgb = (r, g, b, a) => (r * 6553.6) + (g * 25.6) + b * 0.1 - 10000;
  
  /**
   * @param fn DecodeRgbFunction callable or string representation of a DecodeRgbFunction.

--- a/src/worker-util.ts
+++ b/src/worker-util.ts
@@ -2,15 +2,14 @@
 //const canvas = new OffscreenCanvas(256, 256);
 //const ctx = canvas.getContext("2d");
 
-function mapboxTerrainToGrid(png: ndarray<number>, interval?: number, offset?: number) {
+import { DecodeRgbFunction } from "./utils";
+
+function mapboxTerrainToGrid(png: ndarray<number>, decodeRgb: DecodeRgbFunction) {
   // maybe we should do this on the GPU using REGL?
   // but that would require GPU -> CPU -> GPU
   const gridSize = png.shape[0] + 1;
   const terrain = new Float32Array(gridSize * gridSize);
   const tileSize = png.shape[0];
-
-  interval = interval ?? 0.1;
-  offset = offset ?? -10000;
 
   // decode terrain values
   for (let y = 0; y < tileSize; y++) {
@@ -19,8 +18,8 @@ function mapboxTerrainToGrid(png: ndarray<number>, interval?: number, offset?: n
       const r = png.get(x, yc, 0);
       const g = png.get(x, yc, 1);
       const b = png.get(x, yc, 2);
-      terrain[y * gridSize + x] =
-        (r * 256 * 256) * interval + (g * 256.0) * interval + b * interval + offset;
+      const a = png.get(x, yc, 3);
+      terrain[y * gridSize + x] = decodeRgb(r, g, b, a);
     }
   }
   // backfill right and bottom borders


### PR DESCRIPTION
I'd like your thoughts on this concept. Since the datasource of the terrain tiles are now injected into the terrain provider via the *Resource classes, the last remaining assumption in the code is the worker-utils `mapboxTerrainToGrid` function decoding the RGB values to the Terrain-RGB spec.

For my use-case, the source of the terrain tiles defines the RGB encoding scheme. So providing a `decodeRgb` function with the resource allows me to configure everything in one place. The challenge is that the function reference must cross the web worker boundary - which is unsupported. So the function is encoded as a string, sent to the worker, parsed via regex and recreated using `new Function`.

Obviously it comes with some caveats:
- If the `Function.toString()` method returns a string that doesn't match the function-parsing regex, it'll fallback to the Terrain-RGB decoding method.
- The function *must* execute in it's own local scope - no global references, instance variables, etc. Only the provided parameters should be used. I haven't tested security implications of accessing global scoped variables.
- CSP rules may block the `Function` constructor when using custom decode functions. This will fallback to the Terrain-RGB decoding method.

The default behaviour with MapboxTerrainProvider will simply pass nothing for a decoding function, and the worker will fallback to the default Terrain-RGB decode function. This should be equivalent to the current behaviour, without security concerns.

This feature removes the need to pass around interval/offset values too.

Another use-case for this feature can be seen in another fork of cesium-martini, where a developer has used the Mapzen Terrarium format at https://github.com/mlim15/cesium-martini/commit/15a3641018610a18fd505943a0e4c3a790a4428c

This example could be expressed like so:

```typescript
const terrainResource = new DefaultHeightmapResource({
  url: "https://s3.amazonaws.com/elevation-tiles-prod/terrarium/${z}/${x}/${y}.png",
  decodeRgb: (r, g, b) => (r * 256 + g + b / 256) - 32768,
});

const terrainProvider = new MartiniTerrainProvider({
  resource: terrainResource,
  requestVertexNormals: false,
  requestWaterMask: false,
});
```

For my specific use-case, I'm using the alpha component to determine if the cell contains NODATA, so I can construct a decode function like so:

- alpha < 255 = NODATA
- interval = 0.001m
- offset = -11,200m (Mariana Trench)

```typescript
decodeRgb: (r, g, b, a) => a < 255 ? 0 : (r * 256 * 256) * 0.001 + (g * 256) * 0.001 + b * 0.001 - 11200.0
```