### PR TITLE
Reduce excessive quantized-mesh skirt heights

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,11 @@ overall design.
 
 - Fix memory leak where `ArrayBuffer`s were retained due to console logging.
 
+### `[unreleased]`
+
+- Reduce quantized-mesh skirt height to match Cesium's own terrain provider,
+  which avoids exaggerated low-LOD skirt spikes near adjacent terrain.
+
 ### `[1.1.2]`: May 2021
 
 - Fixed a bug with loading high-resolution tiles

--- a/src/terrain-data.ts
+++ b/src/terrain-data.ts
@@ -81,7 +81,9 @@ export function createTerrainMesh(
   } = meta;
 
   const err = errorLevel;
-  const skirtHeight = err * 20;
+  // Match Cesium's own quantized-mesh skirt scale to avoid exaggerated
+  // low-LOD skirts poking through adjacent terrain.
+  const skirtHeight = err * 5;
 
   // Check if tileRect is not NaNs
   if (isNaN(tileRect.east) || isNaN(tileRect.north)) {

--- a/src/terrain-provider.ts
+++ b/src/terrain-provider.ts
@@ -260,7 +260,9 @@ export class MartiniTerrainProvider<TerrainProvider> {
     } = workerOutput;
 
     const err = errorLevel;
-    const skirtHeight = err * 20;
+    // Match Cesium's own quantized-mesh skirt scale to avoid exaggerated
+    // low-LOD skirts poking through adjacent terrain.
+    const skirtHeight = err * 5;
 
     const center = Rectangle.center(tileRect);
 


### PR DESCRIPTION
This aligns `cesium-martini`'s quantized-mesh skirt height with Cesium's own terrain provider.

Today the provider computes skirts as `err * 20`, while Cesium core uses `getLevelMaximumGeometricError(level) * 5.0`.

In practice that larger skirt can show up as exaggerated low-LOD terrain spikes or small pyramids when a coarse tile sits below nearby terrain or water-adjacent terrain.

This change reduces the skirt scale in both terrain-data construction paths so the generated mesh behavior matches Cesium's own terrain pipeline more closely.

Verification:
- `corepack yarn build`
